### PR TITLE
Add Fibonacci in Assembly + Code Links in README

### DIFF
--- a/MohsenBg/fibonacci_number/README.md
+++ b/MohsenBg/fibonacci_number/README.md
@@ -203,5 +203,6 @@ after performing the matrix multiplication, the result will be:
 [F(5) F(4)]
 ```
 
-You can check the Rust code here:  
-#### [Rust Code](./rust/src/lib.rs) 📄💻
+You can check the code here:  
+- 🦀 [Rust Code — O(n log n)](./rust/src/lib.rs)  
+- ⚙️ [Assembly Code — O(n)](./asm/fibonacci.asm)

--- a/MohsenBg/fibonacci_number/README.md
+++ b/MohsenBg/fibonacci_number/README.md
@@ -205,4 +205,4 @@ after performing the matrix multiplication, the result will be:
 
 You can check the code here:  
 - 🦀 [Rust Code — O(n log n)](./rust/src/lib.rs)  
-- ⚙️ [Assembly Code — O(n)](./asm/fibonacci.asm)
+- ⚙️ [Assembly Code — O(n)](./assembly/fibonacci.asm)

--- a/MohsenBg/fibonacci_number/README.md
+++ b/MohsenBg/fibonacci_number/README.md
@@ -204,5 +204,5 @@ after performing the matrix multiplication, the result will be:
 ```
 
 You can check the code here:  
-- 🦀 [Rust Code — O(n log n)](./rust/src/lib.rs)  
+- 🦀 [Rust Code — O(log n)](./rust/src/lib.rs)  
 - ⚙️ [Assembly Code — O(n)](./assembly/fibonacci.asm)

--- a/MohsenBg/fibonacci_number/assembly/.gitignore
+++ b/MohsenBg/fibonacci_number/assembly/.gitignore
@@ -1,0 +1,20 @@
+# Ignore compiled binary files
+two_sum_sorted
+*.exe
+*.out
+*.bin
+
+# Ignore object files
+*.o
+*.obj
+
+# Ignore debugging and core dump files
+*.dSYM/
+*.core
+core
+
+# Ignore temporary files and editor backups
+*.swp
+*.swo
+*.bak
+*~

--- a/MohsenBg/fibonacci_number/assembly/fibonacci.asm
+++ b/MohsenBg/fibonacci_number/assembly/fibonacci.asm
@@ -1,0 +1,53 @@
+%use masm
+
+section .text
+    global fibonacci ; int fibonacci(int n)
+
+%define n rbp - 4
+%define last_value rbp - 8
+%define second_last_value rbp - 12
+
+fibonacci:
+    push rbp
+    mov  rbp, rsp
+    sub  rsp, 16              ; reserve space for locals
+
+    mov  dword ptr [n], edi       ; store input n
+    mov  dword ptr [second_last_value], 0
+    mov  dword ptr [last_value], 1
+
+    ; if n <= 0 return 0
+    cmp  dword ptr [n], 0
+    jg   check_one
+    mov  eax, 0
+    jmp  end_fib
+
+check_one:
+    ; if n == 1 return 1
+    cmp  dword ptr [n], 1
+    jne  loop_start
+    mov  eax, 1
+    jmp  end_fib
+
+loop_start:
+    mov  ecx, 2               ; loop counter
+
+loop:
+    cmp  ecx, dword ptr [n]
+    jg   return_result        ; exit loop if ecx > n
+
+    mov  eax, dword ptr [second_last_value]
+    mov  ebx, dword ptr [last_value]
+    add  eax, ebx
+    mov  dword ptr [second_last_value], ebx
+    mov  dword ptr [last_value], eax
+
+    inc  ecx
+    jmp  loop
+
+return_result:
+    mov  eax, dword ptr [last_value]
+
+end_fib:
+    leave
+    ret

--- a/MohsenBg/fibonacci_number/assembly/main.c
+++ b/MohsenBg/fibonacci_number/assembly/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+// external fibonacci function from assembly
+extern int fibonacci(int n);
+
+int main() {
+    int n = 20;
+    int result = fibonacci(n);
+    printf("fibonacci(%d) = %d\n", n, result);
+    return 0;
+}
+ 


### PR DESCRIPTION
### Add Fibonacci in Assembly + Code Links in README

#### Overview
This PR adds a complete implementation of the **Fibonacci algorithm in x86-64 Assembly**, and updates the `README.md` with links to both the Rust and Assembly versions.

---
#### ✅ What's Added
- New file: `fibonacci.asm` iterative Fibonacci function written in NASM (O(n))
- C main function to call and test the assembly function
- `README.md` updated with:
  - 📄 Link to Rust implementation (O(log n))
  - ⚙️ Link to Assembly implementation (O(n))
